### PR TITLE
Potential fix for code scanning alert no. 2: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -15,6 +15,8 @@ jobs:
   test:
     name: Run Tests
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code
@@ -57,6 +59,8 @@ jobs:
     name: Security Scan
     runs-on: ubuntu-latest
     needs: test
+    permissions:
+      contents: read
     
     steps:
       - name: Checkout code


### PR DESCRIPTION
Potential fix for [https://github.com/Fayeblade1488/deeper_research_synthetic/security/code-scanning/2](https://github.com/Fayeblade1488/deeper_research_synthetic/security/code-scanning/2)

The problem is that the `test` job (and, by extension, the `security` job—since neither sets `permissions` nor inherits it globally) does not explicitly set its required permissions, so it may use broader permissions than necessary. The correct approach is to explicitly restrict the `permissions` at the most restrictive level needed for the job (here, usually `contents: read` suffices for jobs that only need to clone/read repository code).  
To fix this, add a `permissions` block under the `test` job and (optionally) under `security` as well, setting at least `contents: read`.  
Edit `.github/workflows/deploy.yml`, under both the `test:` and `security:` jobs, immediately after the job name and runner fields, add:

```yaml
permissions:
  contents: read
```

No extra methods, imports, or other definitions are required—just this YAML block.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._

## Summary by Sourcery

CI:
- Add explicit permissions block to test and security jobs in deploy workflow to limit contents access to read-only